### PR TITLE
[feature] Calculate validation F1 score during training

### DIFF
--- a/config/config_slakh_f1_0.65.yaml
+++ b/config/config_slakh_f1_0.65.yaml
@@ -54,13 +54,13 @@ trainer:
 
 eval:
   is_sanity_check: False
-  eval_first_n_examples: 
+  eval_first_n_examples: 3
   eval_after_num_epoch: 400
-  eval_per_epoch: 1
-  eval_dataset:
-  exp_tag_name: 
-  audio_dir:
-  midi_dir:
+  eval_per_epoch: 10
+  eval_dataset: "Slakh"
+  exp_tag_name: "val_midis"
+  audio_dir: "/data/slakh2100_flac_redux/validation/*/mix_16k.wav"
+  midi_dir: "/data/slakh2100_flac_redux/validation/"
   contiguous_inference:
   batch_size: 8
   use_tf_spectral_ops: False    # change this to True if using pretrained/mt3.pth

--- a/config/config_slakh_segmem.yaml
+++ b/config/config_slakh_segmem.yaml
@@ -60,10 +60,10 @@ eval:
   eval_first_n_examples: 
   eval_after_num_epoch: 400
   eval_per_epoch: 1
-  eval_dataset:
-  exp_tag_name: 
-  audio_dir:
-  midi_dir:
+  eval_dataset: "Slakh"
+  exp_tag_name: "val_midis"
+  audio_dir: "/data/slakh2100_flac_redux/validation/*/mix_16k.wav"
+  midi_dir: "/data/slakh2100_flac_redux/validation/"
   contiguous_inference:
   batch_size: 8
   use_tf_spectral_ops: False

--- a/config/config_slakh_segmem_finetune.yaml
+++ b/config/config_slakh_segmem_finetune.yaml
@@ -57,13 +57,13 @@ trainer:
 
 eval:
   is_sanity_check: False
-  eval_first_n_examples: 
+  eval_first_n_examples: 3
   eval_after_num_epoch: 400
-  eval_per_epoch: 1
-  eval_dataset:
-  exp_tag_name: 
-  audio_dir:
-  midi_dir:
+  eval_per_epoch: 10
+  eval_dataset: "Slakh"
+  exp_tag_name: "val_midis"
+  audio_dir: "/data/slakh2100_flac_redux/validation/*/mix_16k.wav"
+  midi_dir: "/data/slakh2100_flac_redux/validation/"
   contiguous_inference:
   batch_size: 8
   use_tf_spectral_ops: False

--- a/tasks/mt3_base.py
+++ b/tasks/mt3_base.py
@@ -1,0 +1,50 @@
+from typing import Any
+import pytorch_lightning as pl
+from pytorch_lightning.utilities.rank_zero import rank_zero_only
+import glob
+from test import get_scores
+
+
+class MT3Base(pl.LightningModule):
+    """
+    Base class for MT3 related experiments
+    """
+    def __init__(self, config, optim_cfg, eval_cfg=None):
+        super().__init__()
+        self.config = config
+        self.optim_cfg = optim_cfg
+        self.eval_cfg = eval_cfg
+    
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def training_step(self, batch, batch_idx):
+        raise NotImplementedError
+    
+    def validation_step(self, batch, batch_idx):
+        raise NotImplementedError
+    
+    @rank_zero_only
+    def on_validation_epoch_end(self):
+        if self.current_epoch >= self.eval_cfg.eval_after_num_epoch:
+            if self.current_epoch % self.eval_cfg.eval_per_epoch == 0:
+                eval_audio_dir = sorted(glob.glob(self.eval_cfg.audio_dir))
+                if self.eval_cfg.eval_first_n_examples:
+                    eval_audio_dir = eval_audio_dir[:self.eval_cfg.eval_first_n_examples]
+
+                self.model.eval()
+                scores = get_scores(
+                    model=self.model, 
+                    eval_audio_dir=eval_audio_dir,
+                    eval_dataset="Slakh",
+                    ground_truth_midi_dir=self.eval_cfg.midi_dir,
+                    verbose=False
+                )
+                print(scores)
+
+                self.log('val_f1_flat', scores['Onset F1'], on_step=False, on_epoch=True)
+                self.log('val_f1_midi_class', scores['Onset + program F1 (midi_class)'], on_step=False, on_epoch=True)
+                self.log('val_f1_full', scores['Onset + program F1 (full)'], on_step=False, on_epoch=True)
+    
+    def configure_optimizers(self):
+        raise NotImplementedError

--- a/tasks/mt3_base.py
+++ b/tasks/mt3_base.py
@@ -40,9 +40,8 @@ class MT3Base(pl.LightningModule):
                     ground_truth_midi_dir=self.eval_cfg.midi_dir,
                     verbose=False
                 )
-                print(scores)
 
-                self.log('val_f1_flat', scores['Onset F1'], on_step=False, on_epoch=True)
+                self.log('val_f1_flat', scores['Onset F1'], on_step=False, on_epoch=True, prog_bar=True)
                 self.log('val_f1_midi_class', scores['Onset + program F1 (midi_class)'], on_step=False, on_epoch=True)
                 self.log('val_f1_full', scores['Onset + program F1 (full)'], on_step=False, on_epoch=True)
     

--- a/tasks/mt3_net.py
+++ b/tasks/mt3_net.py
@@ -6,13 +6,12 @@ import torch.nn as nn
 from transformers import T5Config
 from models.t5 import T5ForConditionalGeneration
 from utils import get_cosine_schedule_with_warmup
+from tasks.mt3_base import MT3Base
 
-class MT3Net(pl.LightningModule):
 
-    def __init__(self, config, optim_cfg):
-        super().__init__()
-        self.config = config
-        self.optim_cfg = optim_cfg
+class MT3Net(MT3Base):
+    def __init__(self, config, optim_cfg, eval_cfg=None):
+        super().__init__(config, optim_cfg, eval_cfg=eval_cfg)
         T5config = T5Config.from_dict(OmegaConf.to_container(self.config))
         self.model: nn.Module = T5ForConditionalGeneration(
             T5config
@@ -73,12 +72,9 @@ class MT3Net(pl.LightningModule):
         # return AdamW(self.model.parameters(), self.config.lr)
 
 
-class MT3NetWeightedLoss(pl.LightningModule):
-
-    def __init__(self, config, optim_cfg):
-        super().__init__()
-        self.config = config
-        self.optim_cfg = optim_cfg
+class MT3NetWeightedLoss(MT3Base):
+    def __init__(self, config, optim_cfg, eval_cfg=None):
+        super().__init__(config, optim_cfg, eval_cfg=eval_cfg)
         T5config = T5Config.from_dict(OmegaConf.to_container(self.config))
         self.model: nn.Module = T5ForConditionalGeneration(T5config)
 

--- a/tasks/mt3_net_segmem.py
+++ b/tasks/mt3_net_segmem.py
@@ -6,13 +6,12 @@ import torch.nn as nn
 from transformers import T5Config
 from models.t5_segmem import T5SegMem
 from utils import get_cosine_schedule_with_warmup
+from tasks.mt3_base import MT3Base
 
-class MT3NetSegMem(pl.LightningModule):
 
-    def __init__(self, config, optim_cfg):
-        super().__init__()
-        self.config = config
-        self.optim_cfg = optim_cfg
+class MT3NetSegMem(MT3Base):
+    def __init__(self, config, optim_cfg, eval_cfg=None):
+        super().__init__(config, optim_cfg, eval_cfg=eval_cfg)
         T5config = T5Config.from_dict(OmegaConf.to_container(self.config))
         self.model: nn.Module = T5SegMem(
             config=T5config,

--- a/tasks/mt3_net_segmem_v2.py
+++ b/tasks/mt3_net_segmem_v2.py
@@ -6,13 +6,12 @@ import torch.nn as nn
 from transformers import T5Config
 from models.t5_segmem_v2 import T5SegMemV2
 from utils import get_cosine_schedule_with_warmup
+from tasks.mt3_base import MT3Base
 
-class MT3NetSegMemV2(pl.LightningModule):
 
-    def __init__(self, config, optim_cfg):
-        super().__init__()
-        self.config = config
-        self.optim_cfg = optim_cfg
+class MT3NetSegMemV2(MT3Base):
+    def __init__(self, config, optim_cfg, eval_cfg=None):
+        super().__init__(config, optim_cfg, eval_cfg=eval_cfg)
         T5config = T5Config.from_dict(OmegaConf.to_container(self.config))
         self.model: nn.Module = T5SegMemV2(
             config=T5config,

--- a/tasks/mt3_net_segmem_v2_with_prev.py
+++ b/tasks/mt3_net_segmem_v2_with_prev.py
@@ -6,13 +6,12 @@ import torch.nn as nn
 from transformers import T5Config
 from models.t5_segmem_v2_with_prev import T5SegMemV2WithPrev
 from utils import get_cosine_schedule_with_warmup
+from tasks.mt3_base import MT3Base
 
-class MT3NetSegMemV2WithPrev(pl.LightningModule):
 
-    def __init__(self, config, optim_cfg):
-        super().__init__()
-        self.config = config
-        self.optim_cfg = optim_cfg
+class MT3NetSegMemV2WithPrev(MT3Base):
+    def __init__(self, config, optim_cfg, eval_cfg=None):
+        super().__init__(config, optim_cfg, eval_cfg=eval_cfg)
         T5config = T5Config.from_dict(OmegaConf.to_container(self.config))
         self.model: nn.Module = T5SegMemV2WithPrev(
             config=T5config,

--- a/tasks/mt3_net_segmem_v2_with_prev_finetune.py
+++ b/tasks/mt3_net_segmem_v2_with_prev_finetune.py
@@ -7,12 +7,13 @@ from transformers import T5Config
 from tasks.mt3_net_segmem_v2_with_prev import MT3NetSegMemV2WithPrev
 from utils import get_cosine_schedule_with_warmup
 
-class MT3NetSegMemV2WithPrevFineTune(MT3NetSegMemV2WithPrev):
 
-    def __init__(self, config, optim_cfg):
+class MT3NetSegMemV2WithPrevFineTune(MT3NetSegMemV2WithPrev):
+    def __init__(self, config, optim_cfg, eval_cfg=None):
         super().__init__(
             config=config, 
-            optim_cfg=optim_cfg
+            optim_cfg=optim_cfg,
+            eval_cfg=eval_cfg
         )
 
     def configure_optimizers(self):

--- a/test.py
+++ b/test.py
@@ -10,8 +10,6 @@ import librosa
 import hydra
 import numpy as np
 from evaluate import evaluate_main
-from tasks.mt3_net import MT3Net
-from tasks.mt3_net_segmem import MT3NetSegMem
 
 
 def get_scores(

--- a/test.sh
+++ b/test.sh
@@ -7,11 +7,12 @@ python3 test.py \
     eval.eval_dataset="Slakh" \
     eval.exp_tag_name="slakh_mt3_official" \
     eval.audio_dir="/data/slakh2100_flac_redux/test/*/mix_16k.wav" \
+    eval.midi_dir="/data/slakh2100_flac_redux/test/" \
     hydra/job_logging=disabled \
     eval.is_sanity_check=True   \
     eval.eval_first_n_examples=1 \
     eval.contiguous_inference=False \
-    eval.use_tf_spectral_ops=True \
+    eval.use_tf_spectral_ops=False \
     +eval.load_weights_strict=False \
     # eval.eval_first_n_examples=1 \
 
@@ -27,6 +28,7 @@ python3 test.py \
     eval.eval_dataset="Slakh" \
     eval.exp_tag_name="slakh_mt3_official" \
     eval.audio_dir="/data/slakh2100_flac_redux/test/*/mix_16k.wav" \
+    eval.midi_dir="/data/slakh2100_flac_redux/test/" \
     hydra/job_logging=disabled \
     eval.is_sanity_check=True   \
     eval.contiguous_inference=True \
@@ -44,6 +46,7 @@ python3 test.py \
     eval.eval_dataset="Slakh" \
     eval.exp_tag_name="slakh_mt3_official" \
     eval.audio_dir="/data/slakh2100_flac_redux/test/*/mix_16k.wav" \
+    eval.midi_dir="/data/slakh2100_flac_redux/test/" \
     hydra/job_logging=disabled \
     eval.is_sanity_check=True   \
     eval.contiguous_inference=True \
@@ -61,6 +64,7 @@ python3 test.py \
     eval.eval_dataset="Slakh" \
     eval.exp_tag_name="slakh_mt3_official" \
     eval.audio_dir="/data/slakh2100_flac_redux/test/*/mix_16k.wav" \
+    eval.midi_dir="/data/slakh2100_flac_redux/test/" \
     hydra/job_logging=disabled \
     eval.is_sanity_check=True   \
     eval.contiguous_inference=True \
@@ -78,6 +82,7 @@ python3 test.py \
     eval.eval_dataset="Slakh" \
     eval.exp_tag_name="slakh_mt3_official" \
     eval.audio_dir="/data/slakh2100_flac_redux/test/*/mix_16k.wav" \
+    eval.midi_dir="/data/slakh2100_flac_redux/test/" \
     hydra/job_logging=disabled \
     eval.is_sanity_check=True   \
     eval.contiguous_inference=True \
@@ -95,6 +100,7 @@ python3 test.py \
     eval.eval_dataset="Slakh" \
     eval.exp_tag_name="slakh_mt3_official" \
     eval.audio_dir="/data/slakh2100_flac_redux/test/*/mix_16k.wav" \
+    eval.midi_dir="/data/slakh2100_flac_redux/test/" \
     hydra/job_logging=disabled \
     eval.is_sanity_check=True   \
     eval.contiguous_inference=True \

--- a/train.py
+++ b/train.py
@@ -24,7 +24,11 @@ def main(cfg):
     # set seed to ensure reproducibility
     pl.seed_everything(cfg.seed)
 
-    model = hydra.utils.instantiate(cfg.model, optim_cfg=cfg.optim)
+    model = hydra.utils.instantiate(
+        cfg.model, 
+        optim_cfg=cfg.optim,
+        eval_cfg=cfg.eval    
+    )
     logger = TensorBoardLogger(save_dir='.',
                                name=f"{cfg.model_type}_{cfg.dataset_type}")
     

--- a/train.sh
+++ b/train.sh
@@ -8,6 +8,10 @@ HYDRA_FULL_ERROR=1 OMP_NUM_THREADS=1 python3 train.py \
     model="MT3Net" \
     dataset="Slakh" \
     split_frame_length=2000 \
+    eval.eval_after_num_epoch=400 \
+    eval.eval_first_n_examples=3 \
+    eval.eval_per_epoch=10 \
+    eval.contiguous_inference=False \
 
 #  ======= train segmem with prev_frame and context = N  ======= #
 #  This experiment trains MR-MT3 which takes the immediate previous segment
@@ -25,6 +29,10 @@ HYDRA_FULL_ERROR=1 OMP_NUM_THREADS=1 python3 train.py \
     split_frame_length=2000 \
     model_segmem_length=64 \
     trainer.check_val_every_n_epoch=20 \
+    eval.eval_after_num_epoch=400 \
+    eval.eval_first_n_examples=3 \
+    eval.eval_per_epoch=10 \
+    eval.contiguous_inference=True \
 
 #  ======= train segmem with prev_frame, prev_augment, context = N  ======= #
 #  This experiment trains MR-MT3 which takes the prior segment as memory.
@@ -45,6 +53,10 @@ HYDRA_FULL_ERROR=1 OMP_NUM_THREADS=1 python3 train.py \
     model_segmem_length=64 \
     dataset_prev_augment_frames=3 \
     trainer.check_val_every_n_epoch=20 \
+    eval.eval_after_num_epoch=400 \
+    eval.eval_first_n_examples=3 \
+    eval.eval_per_epoch=10 \
+    eval.contiguous_inference=True \
 
 #  ======= continual training  ======= #
 #  This experiment pre-loads MT3 official checkpoint, and continue training for N epochs
@@ -66,3 +78,7 @@ HYDRA_FULL_ERROR=1 OMP_NUM_THREADS=1 python3 train.py \
     optim.lr=1e-5 \
     num_epochs=100 \
     path="../../../pretrained/mt3.pth" \
+    eval.eval_after_num_epoch=400 \
+    eval.eval_first_n_examples=3 \
+    eval.eval_per_epoch=10 \
+    eval.contiguous_inference=True \


### PR DESCRIPTION
- Added `MT3Base` that implements validation F1 score calculation `on_validation_epoch_end`
    - `eval_after_num_epoch`, `eval_per_epoch ` and `eval_first_n_examples` are configurable. It is suggested to set `eval_after_num_epoch` > 400 because model at early stages transcribes very slowly.
 
- Minor code refactoring to adapt to `MT3Base` and update train/test configs